### PR TITLE
Remove forced .ttf extension

### DIFF
--- a/Brief/rptuletter.sty
+++ b/Brief/rptuletter.sty
@@ -69,12 +69,10 @@
 	% ItalicFont = RedHatText-LightItalic.ttf ,
 	% BoldItalicFont = RedHatText-SemiBoldItalic.ttf ]%
 	\setmainfont{RedHatText-Regular}[%
-	Extension = .ttf,
 	BoldFont = RedHatText-Bold,
 	ItalicFont = RedHatText-Italic,
 	BoldItalicFont = RedHatText-BoldItalic]%
 	\setmonofont{RedHatMono-Regular}[%
-	Extension = .ttf,
 	BoldFont = RedHatMono-Bold,
 	ItalicFont = RedHatMono-Italic,
 	BoldItalicFont = RedHatMono-BoldItalic]%

--- a/LaTeX-Beamer/beamerthemeRPTU.sty
+++ b/LaTeX-Beamer/beamerthemeRPTU.sty
@@ -252,17 +252,14 @@
 			%% works only with LuaLaTeX (and XeLaTeX)
 			\RequirePackage{fontspec}%
 			\setmainfont{RedHatText-Regular}[%
-				Extension = .ttf,
 				BoldFont = RedHatText-Bold,
 				ItalicFont = RedHatText-Italic,
 				BoldItalicFont = RedHatText-BoldItalic]%
 			\setsansfont{RedHatText-Regular}[%
-				Extension = .ttf,
 				BoldFont = RedHatText-Bold,
 				ItalicFont = RedHatText-Italic,
 				BoldItalicFont = RedHatText-BoldItalic]%
 			\setmonofont{RedHatMono-Regular}[%
-				Extension = .ttf,
 				BoldFont = RedHatMono-Bold,
 				ItalicFont = RedHatMono-Italic,
 				BoldItalicFont = RedHatMono-BoldItalic]%


### PR DESCRIPTION
Hi!
Thanks for the nice templates. I'm currently preparing a talk with the beamer template and noticed a minor problem with the font loading. I'm compiling with `lualatex` and the Red Hat Text fonts are installed as `.otf` files on my machine. Since you hardcoded the template to expect `.ttf` files it failed to build. Is there a particular reason for this? At least over here it seems fine without these `Extension = .ttf` lines.